### PR TITLE
Cache generated assets

### DIFF
--- a/lib/rack/pagespeed.rb
+++ b/lib/rack/pagespeed.rb
@@ -34,7 +34,11 @@ module Rack
       if asset = store[asset_id]
         [
           200,
-          { 'Content-Type' => (Rack::Mime.mime_type(::File.extname(asset_id))) },
+          {
+            'Content-Type' => (Rack::Mime.mime_type(::File.extname(asset_id))),
+            'Cache-Control' => "public, max-age=#{(60*60*24*365.25*10).to_i}",
+            'Expires' => (Time.now + 60*60*24*365.25*10).httpdate
+          },
           [asset]
         ]
       else

--- a/spec/pagespeed_spec.rb
+++ b/spec/pagespeed_spec.rb
@@ -86,6 +86,11 @@ describe 'rack-pagespeed' do
       it "responds with HTTP 200" do
         @status.should == 200
       end
+      
+      it "instructs clients to cache asset for 10 years" do
+        @headers['Cache-Control'].should == "public, max-age=315576000"
+        Time.parse(@headers['Expires']).to_i.should be_within(10).of(Time.now.to_i + 315576000)
+      end
     end
   end
   


### PR DESCRIPTION
In the name of web performance, the generated assets should expire far into the future. So I’ve added Cache-Control and Expires headers to the response.

Thanks for making this!
