### PR TITLE
Added automatic start and stop of Redis and memcached before running specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle
 .rvmrc
+spec/db/*

--- a/Rakefile
+++ b/Rakefile
@@ -34,3 +34,5 @@ namespace :spec do
     system "rvm 1.8.7-p174,1.9.2 specs"
   end
 end
+
+task :default => :spec

--- a/spec/redis_test.conf
+++ b/spec/redis_test.conf
@@ -1,0 +1,8 @@
+dir ./spec/db
+pidfile ./redis.pid
+port 6379
+timeout 300
+loglevel debug
+logfile stdout
+databases 16
+daemonize yes


### PR DESCRIPTION
You can now use: rake spec_with_services which will start Redis and memcached before running the specs as well as cleanup those processes after the specs have run. This was convenient for me as I usually don't remember to start/stop those services all the time.

I didn't make spec_with_services the default task run when you run rake by itself. I did make spec the default task so it doesn't complain when usually you want to run the specs by default.  

Hope this is useful.
