### PR TITLE
Cleaned up the gemspec and Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle
 .rvmrc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,3 @@
 source :rubygems
 
-gem 'rack'    # Just let it work with latest. If the API breaks, I'll fix it
-gem 'nokogiri'
-gem 'jsmin'
-gem 'dalli'
-
-group :test do
-  gem 'rspec',    '2.3.0'
-  gem 'steak',    '1.0.0'
-  gem 'capybara', '0.4.0'
-  gem 'redis'
-  gem 'memcached'
-end
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -15,14 +15,15 @@ begin
     gem.email               = "julio@awesomebydesign.com"
     gem.homepage            = "http://github.com/juliocesar/rack-pagespeed"
     gem.authors             = "Julio Cesar Ody"
-    gem.add_dependency      'nokogiri',   '1.4.4'
-    gem.add_dependency      'rack',       '1.2.1'
-    gem.add_dependency      'memcached',  '1.0.2'
-    gem.add_dependency      'mime-types', '1.16'
-    gem.add_dependency      'jsmin',      '1.0.1'
-    gem.add_development_dependency 'rspec', '2.1.0'
-    gem.add_development_dependency 'steak', '1.0.0'
-    gem.add_development_dependency 'capybara', '0.4.0'
+    gem.add_dependency      'nokogiri'
+    gem.add_dependency      'rack'
+    gem.add_dependency      'mime-types'
+    gem.add_dependency      'jsmin'
+    gem.add_development_dependency 'redis'
+    gem.add_development_dependency 'dalli'
+    gem.add_development_dependency 'rspec', '~> 2.3.0'
+    gem.add_development_dependency 'steak', '~> 1.0.0'
+    gem.add_development_dependency 'capybara', '~> 0.4.0'
   end
 rescue LoadError
   puts 'Jeweler not available. gemspec tasks OFF.'

--- a/rack-pagespeed.gemspec
+++ b/rack-pagespeed.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.version = "1.0.9"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = [%q{Julio Cesar Ody}]
-  s.date = %q{2011-06-13}
+  s.authors = ["Julio Cesar Ody"]
+  s.date = %q{2011-08-04}
   s.description = %q{Web page speed optimizations at the Rack level}
   s.email = %q{julio@awesomebydesign.com}
   s.extra_rdoc_files = [
@@ -85,26 +85,9 @@ Gem::Specification.new do |s|
     "spec/store/redis_spec.rb"
   ]
   s.homepage = %q{http://github.com/juliocesar/rack-pagespeed}
-  s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.5}
+  s.require_paths = ["lib"]
+  s.rubygems_version = %q{1.6.2}
   s.summary = %q{Web page speed optimizations at the Rack level}
-  s.test_files = [
-    "spec/config_spec.rb",
-    "spec/filters/combine_css_spec.rb",
-    "spec/filters/combine_javascripts_spec.rb",
-    "spec/filters/filter_spec.rb",
-    "spec/filters/inline_css_spec.rb",
-    "spec/filters/inline_images_spec.rb",
-    "spec/filters/inline_javascript_spec.rb",
-    "spec/filters/minify_javascript_spec.rb",
-    "spec/fixtures/mock_store.rb",
-    "spec/integration/integration_spec.rb",
-    "spec/pagespeed_spec.rb",
-    "spec/spec_helper.rb",
-    "spec/store/disk_spec.rb",
-    "spec/store/memcached_spec.rb",
-    "spec/store/redis_spec.rb"
-  ]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
@@ -113,42 +96,42 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
       s.add_runtime_dependency(%q<jsmin>, [">= 0"])
-      s.add_runtime_dependency(%q<dalli>, [">= 0"])
-      s.add_runtime_dependency(%q<nokogiri>, ["= 1.4.4"])
-      s.add_runtime_dependency(%q<rack>, ["= 1.2.1"])
-      s.add_runtime_dependency(%q<memcached>, ["= 1.0.2"])
-      s.add_runtime_dependency(%q<mime-types>, ["= 1.16"])
-      s.add_runtime_dependency(%q<jsmin>, ["= 1.0.1"])
-      s.add_development_dependency(%q<rspec>, ["= 2.1.0"])
-      s.add_development_dependency(%q<steak>, ["= 1.0.0"])
-      s.add_development_dependency(%q<capybara>, ["= 0.4.0"])
+      s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
+      s.add_runtime_dependency(%q<rack>, [">= 0"])
+      s.add_runtime_dependency(%q<mime-types>, [">= 0"])
+      s.add_runtime_dependency(%q<jsmin>, [">= 0"])
+      s.add_development_dependency(%q<redis>, [">= 0"])
+      s.add_development_dependency(%q<dalli>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, ["~> 2.3.0"])
+      s.add_development_dependency(%q<steak>, ["~> 1.0.0"])
+      s.add_development_dependency(%q<capybara>, ["~> 0.4.0"])
     else
       s.add_dependency(%q<rack>, [">= 0"])
       s.add_dependency(%q<nokogiri>, [">= 0"])
       s.add_dependency(%q<jsmin>, [">= 0"])
+      s.add_dependency(%q<nokogiri>, [">= 0"])
+      s.add_dependency(%q<rack>, [">= 0"])
+      s.add_dependency(%q<mime-types>, [">= 0"])
+      s.add_dependency(%q<jsmin>, [">= 0"])
+      s.add_dependency(%q<redis>, [">= 0"])
       s.add_dependency(%q<dalli>, [">= 0"])
-      s.add_dependency(%q<nokogiri>, ["= 1.4.4"])
-      s.add_dependency(%q<rack>, ["= 1.2.1"])
-      s.add_dependency(%q<memcached>, ["= 1.0.2"])
-      s.add_dependency(%q<mime-types>, ["= 1.16"])
-      s.add_dependency(%q<jsmin>, ["= 1.0.1"])
-      s.add_dependency(%q<rspec>, ["= 2.1.0"])
-      s.add_dependency(%q<steak>, ["= 1.0.0"])
-      s.add_dependency(%q<capybara>, ["= 0.4.0"])
+      s.add_dependency(%q<rspec>, ["~> 2.3.0"])
+      s.add_dependency(%q<steak>, ["~> 1.0.0"])
+      s.add_dependency(%q<capybara>, ["~> 0.4.0"])
     end
   else
     s.add_dependency(%q<rack>, [">= 0"])
     s.add_dependency(%q<nokogiri>, [">= 0"])
     s.add_dependency(%q<jsmin>, [">= 0"])
+    s.add_dependency(%q<nokogiri>, [">= 0"])
+    s.add_dependency(%q<rack>, [">= 0"])
+    s.add_dependency(%q<mime-types>, [">= 0"])
+    s.add_dependency(%q<jsmin>, [">= 0"])
+    s.add_dependency(%q<redis>, [">= 0"])
     s.add_dependency(%q<dalli>, [">= 0"])
-    s.add_dependency(%q<nokogiri>, ["= 1.4.4"])
-    s.add_dependency(%q<rack>, ["= 1.2.1"])
-    s.add_dependency(%q<memcached>, ["= 1.0.2"])
-    s.add_dependency(%q<mime-types>, ["= 1.16"])
-    s.add_dependency(%q<jsmin>, ["= 1.0.1"])
-    s.add_dependency(%q<rspec>, ["= 2.1.0"])
-    s.add_dependency(%q<steak>, ["= 1.0.0"])
-    s.add_dependency(%q<capybara>, ["= 0.4.0"])
+    s.add_dependency(%q<rspec>, ["~> 2.3.0"])
+    s.add_dependency(%q<steak>, ["~> 1.0.0"])
+    s.add_dependency(%q<capybara>, ["~> 0.4.0"])
   end
 end
 


### PR DESCRIPTION
1. There is no need to maintain both the gemspec and the Gemfile.
2. The gemspec is out of date, resulting in rack and nokogiri conflicts with other libraries.

Also, I would strongly recommend getting rid of the use of Jeweler and simply use Bundler to maintain the dependencies.
