### PR TITLE
Fixes rack-pagespeed issues on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,16 @@
 source :rubygems
 
+# Include all the gems from the Gemspec
+gemspec
+
 gem 'rack'    # Just let it work with latest. If the API breaks, I'll fix it
 gem 'nokogiri'
 gem 'jsmin'
 gem 'dalli'
+
+# Required for development
+gem 'rake'
+gem 'jeweler'
 
 group :test do
   gem 'rspec',    '2.6.0'

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,10 @@ begin
     gem.add_dependency      'memcached'
     gem.add_dependency      'mime-types'
     gem.add_dependency      'jsmin'
+    gem.add_development_dependency 'rake'
     gem.add_development_dependency 'rspec', '2.6.0'
     gem.add_development_dependency 'capybara', '1.1.0'
+    gem.add_development_dependency 'jeweler', '~> 1.8.3'
   end
 rescue LoadError
   puts 'Jeweler not available. gemspec tasks OFF.'

--- a/rack-pagespeed.gemspec
+++ b/rack-pagespeed.gemspec
@@ -4,14 +4,14 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{rack-pagespeed}
+  s.name = "rack-pagespeed"
   s.version = "1.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = [%q{Julio Cesar Ody}]
-  s.date = %q{2011-08-11}
-  s.description = %q{Web page speed optimizations at the Rack level}
-  s.email = %q{julio@awesomebydesign.com}
+  s.authors = ["Julio Cesar Ody"]
+  s.date = "2012-03-18"
+  s.description = "Web page speed optimizations at the Rack level"
+  s.email = "julio@awesomebydesign.com"
   s.extra_rdoc_files = [
     "README.md"
   ]
@@ -66,51 +66,69 @@ Gem::Specification.new do |s|
     "spec/store/memcached_spec.rb",
     "spec/store/redis_spec.rb"
   ]
-  s.homepage = %q{http://github.com/juliocesar/rack-pagespeed}
-  s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.5}
-  s.summary = %q{Web page speed optimizations at the Rack level}
+  s.homepage = "http://github.com/juliocesar/rack-pagespeed"
+  s.require_paths = ["lib"]
+  s.rubygems_version = "1.8.15"
+  s.summary = "Web page speed optimizations at the Rack level"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<rack-pagespeed>, [">= 0"])
       s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
       s.add_runtime_dependency(%q<jsmin>, [">= 0"])
       s.add_runtime_dependency(%q<dalli>, [">= 0"])
+      s.add_runtime_dependency(%q<rack>, [">= 0"])
+      s.add_runtime_dependency(%q<jeweler>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, ["= 2.6.0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
       s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_runtime_dependency(%q<memcached>, [">= 0"])
       s.add_runtime_dependency(%q<mime-types>, [">= 0"])
       s.add_runtime_dependency(%q<jsmin>, [">= 0"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["= 2.6.0"])
       s.add_development_dependency(%q<capybara>, ["= 1.1.0"])
+      s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
     else
+      s.add_dependency(%q<rack-pagespeed>, [">= 0"])
       s.add_dependency(%q<rack>, [">= 0"])
       s.add_dependency(%q<nokogiri>, [">= 0"])
       s.add_dependency(%q<jsmin>, [">= 0"])
       s.add_dependency(%q<dalli>, [">= 0"])
+      s.add_dependency(%q<rack>, [">= 0"])
+      s.add_dependency(%q<jeweler>, [">= 0"])
+      s.add_dependency(%q<rspec>, ["= 2.6.0"])
       s.add_dependency(%q<nokogiri>, [">= 0"])
       s.add_dependency(%q<rack>, [">= 0"])
       s.add_dependency(%q<memcached>, [">= 0"])
       s.add_dependency(%q<mime-types>, [">= 0"])
       s.add_dependency(%q<jsmin>, [">= 0"])
+      s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rspec>, ["= 2.6.0"])
       s.add_dependency(%q<capybara>, ["= 1.1.0"])
+      s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
     end
   else
+    s.add_dependency(%q<rack-pagespeed>, [">= 0"])
     s.add_dependency(%q<rack>, [">= 0"])
     s.add_dependency(%q<nokogiri>, [">= 0"])
     s.add_dependency(%q<jsmin>, [">= 0"])
     s.add_dependency(%q<dalli>, [">= 0"])
+    s.add_dependency(%q<rack>, [">= 0"])
+    s.add_dependency(%q<jeweler>, [">= 0"])
+    s.add_dependency(%q<rspec>, ["= 2.6.0"])
     s.add_dependency(%q<nokogiri>, [">= 0"])
     s.add_dependency(%q<rack>, [">= 0"])
     s.add_dependency(%q<memcached>, [">= 0"])
     s.add_dependency(%q<mime-types>, [">= 0"])
     s.add_dependency(%q<jsmin>, [">= 0"])
+    s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rspec>, ["= 2.6.0"])
     s.add_dependency(%q<capybara>, ["= 1.1.0"])
+    s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
   end
 end
 


### PR DESCRIPTION
The `rack-pagespeed` gem from rubygems.org wouldn't install on Heroku ("Invalid gemspec") and regenerating the gemspec fixed these issues.

At the same time I added a couple of development dependencies to the gemspec.
